### PR TITLE
Remove useless type attribute from snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ bower install petrovich
 В браузере:
 
 ```html
-<script type="text/javascript" src="/path/to/petrovich/dist/petrovich.min.js"></script>
+<script src="/path/to/petrovich/dist/petrovich.min.js"></script>
 ```
 
 В NodeJS:


### PR DESCRIPTION
Type attribute on `<script>` is completely useless in all cases, unless it’s `type="module"` or you’re using VBScript.